### PR TITLE
Fix: `required` as default, and not required

### DIFF
--- a/unmarshal.go
+++ b/unmarshal.go
@@ -3,7 +3,6 @@ package env
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -88,26 +87,27 @@ type tagOptions struct {
 
 // parseTag parses the struct tag into tagOptions
 func parseTag(tag string) tagOptions {
-	parts := strings.SplitN(tag, ",", 2)
+	parts := strings.Split(tag, ",")
+
+	// Keys are separated by | in the first part
 	keys := strings.Split(parts[0], "|")
+
+	// Initialize fallback value and required flag
 	var fallbackValue string
 	required := false
+
+	// Process extra parts (default, fallback, required)
 	if len(parts) > 1 {
-		extraParts := parts[1]
-		if strings.Contains(extraParts, "default=[") || strings.Contains(extraParts, "fallback=[") {
-			re := regexp.MustCompile(`(?:default|fallback)=\[(.*?)\]`)
-			matches := re.FindStringSubmatch(extraParts)
-			if len(matches) > 1 {
-				fallbackValue = matches[1]
-			}
-		} else if strings.Contains(extraParts, "default=") || strings.Contains(extraParts, "fallback=") {
-			re := regexp.MustCompile(`(?:default|fallback)=([^,]+)`)
-			matches := re.FindStringSubmatch(extraParts)
-			if len(matches) > 1 {
-				fallbackValue = matches[1]
+		for _, part := range parts[1:] {
+			switch {
+			case strings.HasPrefix(part, "default="):
+				fallbackValue = strings.TrimPrefix(part, "default=")
+			case strings.HasPrefix(part, "fallback="):
+				fallbackValue = strings.TrimPrefix(part, "fallback=")
+			case part == "required":
+				required = true
 			}
 		}
-		required = strings.Contains(extraParts, "required")
 	}
 
 	return tagOptions{

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -399,3 +399,54 @@ func TestUnmarshalSliceFloatError(t *testing.T) {
 	err := Unmarshal(&cfg)
 	assertError(t, err, "Unmarshal SliceFloatError")
 }
+
+func TestParseTag(t *testing.T) {
+	type TestCase struct {
+		Tag          string
+		ExpectedOpts tagOptions
+	}
+
+	testCases := []TestCase{
+		{
+			Tag: "NOT_REQUIRED,default=required",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"NOT_REQUIRED"},
+				fallback: "required",
+				required: false,
+			},
+		},
+		{
+			Tag: "REQUIRED,required",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"REQUIRED"},
+				fallback: "",
+				required: true,
+			},
+		},
+		{
+			Tag: "REQUIRED_WITH_DEFAULT,default=default,required",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"REQUIRED_WITH_DEFAULT"},
+				fallback: "default",
+				required: true,
+			},
+		},
+		{
+			Tag: "SINGLE_KEY,required,default=default",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"SINGLE_KEY"},
+				fallback: "default",
+				required: true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Tag, func(t *testing.T) {
+			opts := parseTag(tc.Tag)
+			if !reflect.DeepEqual(opts, tc.ExpectedOpts) {
+				t.Errorf("parseTag(%s) returned %+v, expected %+v", tc.Tag, opts, tc.ExpectedOpts)
+			}
+		})
+	}
+}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -439,6 +439,22 @@ func TestParseTag(t *testing.T) {
 				required: true,
 			},
 		},
+		{
+			Tag: "MULTI_KEY1|MULTI_KEY2|MULTI_KEY3,required,default=default",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"MULTI_KEY1", "MULTI_KEY2", "MULTI_KEY3"},
+				fallback: "default",
+				required: true,
+			},
+		},
+		{
+			Tag: "SQUARE_BRACKETS,default=[item1,item2,item3]",
+			ExpectedOpts: tagOptions{
+				keys:     []string{"SQUARE_BRACKETS"},
+				fallback: "item1,item2,item3",
+				required: false,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes a bug where the `default=required` made the `required` tagOption trigger.